### PR TITLE
keep /cluster_details fields consistent with JSON returned by /report endpoint

### DIFF
--- a/types.go
+++ b/types.go
@@ -232,7 +232,7 @@ type HittingClustersMetadata struct {
 type HittingClustersData struct {
 	Cluster  ClusterName `json:"cluster"`
 	Name     string      `json:"cluster_name"`
-	LastSeen string      `json:"generated_at"`
+	LastSeen string      `json:"last_checked_at"`
 	//Version     string      `json:"version"`
 }
 


### PR DESCRIPTION
Use `last_checked_at` in the JSON to keep it consistent with the same field in /report endpoint