### PR TITLE
modify RecommendationImpactedClusters type

### DIFF
--- a/types.go
+++ b/types.go
@@ -343,7 +343,7 @@ type SystemWideRuleDisable struct {
 type ImpactedClustersCnt uint32
 
 // RecommendationImpactedClusters is returned by aggregator for the purposes of /rule/ recommendation list endpoint
-type RecommendationImpactedClusters map[RuleID]ImpactedClustersCnt
+type RecommendationImpactedClusters map[RuleID][]ClusterName
 
 // RecommendationRow represents a single row in the recommendation table
 type RecommendationRow struct {


### PR DESCRIPTION
modify RecommendationImpactedClusters type to return a list of cluster IDs, not only the total number.