### PR TITLE
Omit empty timestamp in metadata (report's JSON)

### DIFF
--- a/types.go
+++ b/types.go
@@ -87,7 +87,7 @@ type ReportResponse struct {
 type ReportResponseMeta struct {
 	DisplayName   string    `json:"cluster_name"`
 	Count         int       `json:"count"`
-	LastCheckedAt Timestamp `json:"last_checked_at"`
+	LastCheckedAt Timestamp `json:"last_checked_at,omitempty"`
 }
 
 // ReportResponseMetainfo contains just metadata about the report, to be used


### PR DESCRIPTION
Returns the report JSON object without "last_checked_at" field when timestamp cannot be retrieved.