### PR TITLE
Add version into ClusterRecommendationList

### DIFF
--- a/types.go
+++ b/types.go
@@ -398,8 +398,9 @@ type RuleParsingError string
 
 // ClusterRecommendationList is used for the clusters list
 type ClusterRecommendationList struct {
-	CreatedAt       time.Time `json:"created_at"`
-	Recommendations []RuleID  `json:"recommendations"`
+	CreatedAt       time.Time       `json:"created_at"`
+	Meta            ClusterMetadata `json:"meta"`
+	Recommendations []RuleID        `json:"recommendations"`
 }
 
 // ClusterRecommendationMap is used for the clusters list


### PR DESCRIPTION
Adding the `"cluster_version"` attribute to the `ClusterRecommendationList` struct in order to being able to retrieve it from the aggregator to the smart proxy.

This change will affecto to both v1 and v2 endpoint handlers, but the only v1 handler using it is not using the new field to generate the response, so it won't affect to the response, only to the communication between Smart Proxy and aggregator.
