### PR TITLE
[CCXDEV-12634] Splitting linters into separate steps in CI

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -19,5 +19,23 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Style linters
-        run: make style
+      - name: GO formatting
+        run: make fmt
+      - name: GO lint 
+        run: make lint
+      - name: GO vet
+        run: make vet
+      - name: gocyclo
+        run: make cyclo
+      - name: shellcheck
+        run: make shellcheck
+      - name: errcheck
+        run: make errcheck
+      - name: goconst checker
+        run: make goconst
+      - name: gosec checker
+        run: make gosec
+      - name: ineffassign checker
+        run: make ineffassign
+      - name: ABC metrics checker
+        run: make abcgo


### PR DESCRIPTION
# Description

Splitting linter job in CI to separate steps.

Fixes [CCXDEV-12634](https://issues.redhat.com/browse/CCXDEV-12634)

## Type of change

Please delete options that are not relevant.


- Configuration update

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
